### PR TITLE
Fix /etc/hosts in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ vagrant provision
 And add an entry to your **hosts** file:
 
 ```bash
-echo 'zidisha.dev     192.168.90.103' | sudo tee -a /etc/hosts
+echo '192.168.90.103     zidisha.dev' | sudo tee -a /etc/hosts
 ```
 
 Fire up a browser and visit - http://zidisha.dev/.


### PR DESCRIPTION
The hosts file contains lines of text consisting of an IP address in the first text field followed by one or more host names.

The prior line had these reverse.
